### PR TITLE
[FIX] 일반공지 즐겨찾기 반환값 수정

### DIFF
--- a/src/main/java/depth/mvp/thinkerbell/domain/user/service/BookmarkService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/service/BookmarkService.java
@@ -204,7 +204,7 @@ public class BookmarkService {
             }
         }
         if (!markedNormalNoticeDtos.isEmpty()) {
-            result.put("markedNormalNotice", markedNormalNoticeDtos);
+            result.put("NormalNotice", markedNormalNoticeDtos);
         }
 
         // AcademicNotice


### PR DESCRIPTION
markedNormalNotice -> NormalNotice로 수정

## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 즐겨찾기 내역 조회 시 일반공지 반환값이 다르게 표시되는 문제 해결

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
데모데이 시연 때, 즐겨찾기 내역에서 일반공지만 markedNormalNotice로 반환되어 표시되지 않는 문제 해결했습니다.

## Reference 🔬
 <!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
