### PR TITLE
[FEAT] getAlarm API 카테고리 영문명 및 URI 수정

### DIFF
--- a/src/main/java/depth/mvp/thinkerbell/domain/user/controller/AlarmController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/controller/AlarmController.java
@@ -60,7 +60,7 @@ public class AlarmController {
             @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
-    @GetMapping("/get")
+    @GetMapping("")
     public ApiResult<List<AlarmDto>> getAlarm(@RequestParam String SSAID, @RequestParam String keyword) {
             List<AlarmDto> alarms = alarmService.getAlarms(SSAID, keyword);
             return ApiResult.ok(alarms);

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/service/AlarmService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/service/AlarmService.java
@@ -14,6 +14,7 @@ import depth.mvp.thinkerbell.domain.user.repository.AlarmRepository;
 import depth.mvp.thinkerbell.domain.user.repository.BookmarkRepository;
 import depth.mvp.thinkerbell.domain.user.repository.KeywordRepository;
 import depth.mvp.thinkerbell.domain.user.repository.UserRepository;
+import depth.mvp.thinkerbell.global.converter.CaseConverter;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.PersistenceContext;
@@ -224,7 +225,7 @@ public class AlarmService {
                             .id(alarm.getId())
                             .title(alarm.getTitle())
                             .noticeTypeKorean(categoryService.getCategoryNameInKorean(alarm.getNoticeType()))
-                            .noticeTypeEnglish(alarm.getNoticeType())
+                            .noticeTypeEnglish(CaseConverter.snakeToPascal(alarm.getNoticeType()))
                             .isViewed(alarm.getIsViewed())
                             .isMarked(isMarked)
                             .Url(null)
@@ -242,7 +243,7 @@ public class AlarmService {
                             .id(alarm.getId())
                             .title(alarm.getTitle())
                             .noticeTypeKorean(categoryService.getCategoryNameInKorean(alarm.getNoticeType()))
-                            .noticeTypeEnglish(alarm.getNoticeType())
+                            .noticeTypeEnglish(CaseConverter.snakeToPascal(alarm.getNoticeType()))
                             .isViewed(alarm.getIsViewed())
                             .isMarked(isMarked)
                             .Url(url)

--- a/src/main/java/depth/mvp/thinkerbell/global/converter/CaseConverter.java
+++ b/src/main/java/depth/mvp/thinkerbell/global/converter/CaseConverter.java
@@ -1,0 +1,57 @@
+package depth.mvp.thinkerbell.global.converter;
+
+public class CaseConverter {
+
+    /**
+     * PascalCase 문자열을 snake_case 문자열로 변환합니다.
+     *
+     * @param pascalCaseString 변환할 PascalCase 문자열
+     * @return 변환된 snake_case 문자열
+     */
+    public static String pascalToSnake(String pascalCaseString) {
+        StringBuilder snakeCaseString = new StringBuilder();
+
+        for (char c : pascalCaseString.toCharArray()) {
+            if (Character.isUpperCase(c)) {
+                if (snakeCaseString.length() > 0) {
+                    snakeCaseString.append('_');
+                }
+                snakeCaseString.append(Character.toLowerCase(c));
+            } else {
+                snakeCaseString.append(c);
+            }
+        }
+
+        return snakeCaseString.toString();
+    }
+
+    /**
+     * snake_case 문자열을 PascalCase 문자열로 변환합니다.
+     *
+     * @param snakeCaseString 변환할 snake_case 문자열
+     * @return 변환된 PascalCase 문자열
+     */
+    public static String snakeToPascal(String snakeCaseString) {
+        StringBuilder pascalCaseString = new StringBuilder();
+        boolean toUpperCase = true;  // 첫 문자를 대문자로 변환하기 위해 true로 설정
+
+        for (char c : snakeCaseString.toCharArray()) {
+            if (c == '_') {
+                // 언더스코어 다음 문자를 대문자로 변환하도록 설정합니다.
+                toUpperCase = true;
+            } else {
+                if (toUpperCase) {
+                    // 대문자로 변환 후 설정을 초기화합니다.
+                    pascalCaseString.append(Character.toUpperCase(c));
+                    toUpperCase = false;
+                } else {
+                    // 소문자로 추가합니다.
+                    pascalCaseString.append(c);
+                }
+            }
+        }
+
+        return pascalCaseString.toString();
+    }
+
+}


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 카테고리 영문명 조회 시 PascalCase로 반환하도록 수정
- [x] getAlarm API의 URI를 "/get" -> ""로 수정

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! --> 이전에 해당 내용에 관한 PR을 올린 적이 있었는데, 충돌 해결 과정에서 내용이 삭제된 것 같아 복구하였습니다. get URI 또한 당시 ""로 수정했었는데, 마찬가지로 복구되어있어 다시 위 내용과 같이 수정했습니다.

## Reference 🔬
 <!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
RESTful API에 관한 내용을 찾아보시면 좋을 것 같습니다.