### PR TITLE
[FIX] 알림에 키워드와 관련한 공지가 모두 보이는 기능 수정 및 알림 테스트 API 추가

### DIFF
--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/AcademicNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/AcademicNoticeRepository.java
@@ -19,5 +19,5 @@ public interface AcademicNoticeRepository extends JpaRepository<AcademicNotice, 
     List<AcademicNotice> findAllByImportantTrueOrderByPubDateDesc();
     Page<AcademicNotice> findAllByImportantFalseOrderByPubDateDesc(Pageable latestPageable);
     List<AcademicNotice> findTop3ByOrderByPubDateDesc();
-
+    List<AcademicNotice> findAllByImportantFalse();
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/DormitoryEntryNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/DormitoryEntryNoticeRepository.java
@@ -23,4 +23,6 @@ public interface DormitoryEntryNoticeRepository extends JpaRepository<DormitoryE
     Page<DormitoryEntryNotice> findAllByImportantFalseAndCampusOrderByPubDateDesc(Pageable pageable, @Param("campuses") List<String> campuses);
 
     DormitoryEntryNotice findOneById(Long noticeID);
+
+    List<DormitoryEntryNotice> findAllByImportantFalse();
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/DormitoryNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/DormitoryNoticeRepository.java
@@ -22,4 +22,6 @@ public interface DormitoryNoticeRepository extends JpaRepository<DormitoryNotice
     Page<DormitoryNotice> findAllByImportantFalseAndCampusOrderByPubDateDesc(Pageable pageable, @Param("campuses") List<String> campuses);
 
     DormitoryNotice findOneById(Long id);
+
+    List<DormitoryNotice> findAllByImportantFalse();
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/LibraryNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/LibraryNoticeRepository.java
@@ -22,4 +22,6 @@ public interface LibraryNoticeRepository extends JpaRepository<LibraryNotice, Lo
     Page<LibraryNotice> findAllByImportantFalseAndCampusOrderByPubDateDesc(Pageable pageable, @Param("campuses") List<String> campuses);
 
     LibraryNotice findOneById(Long noticeID);
+
+    List<LibraryNotice> findAllByImportantFalse();
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/NormalNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/NormalNoticeRepository.java
@@ -21,5 +21,5 @@ public interface NormalNoticeRepository  extends JpaRepository<NormalNotice, Lon
     List<NormalNotice> findAllByImportantTrueOrderByPubDateDesc();
     Page<NormalNotice> findAllByImportantFalseOrderByPubDateDesc(Pageable latestPageable);
     List<NormalNotice> findTop3ByOrderByPubDateDesc();
-
+    List<NormalNotice> findAllByImportantFalse();
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/TeachingNoticeRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/repository/TeachingNoticeRepository.java
@@ -20,4 +20,6 @@ public interface TeachingNoticeRepository extends JpaRepository<TeachingNotice, 
     Page<TeachingNotice> findAllByImportantFalseOrderByPubDateDesc(Pageable pageable);
 
     TeachingNotice findOneById(Long noticeID);
+
+    List<TeachingNotice> findAllByImportantFalse();
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/controller/AlarmController.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/controller/AlarmController.java
@@ -18,6 +18,17 @@ public class AlarmController {
 
     private final AlarmService alarmService;
 
+    @Operation(summary = "알림 기능 테스트", description = "사용자 SSAID와 키워드로 알림 기능을 확인합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "성공적으로 확인됨"),
+            @ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+            @ApiResponse(responseCode = "500", description = "서버 오류 발생")
+    })
+    @GetMapping("/alarm-test")
+    public void testAlarm(@RequestParam String SSAID, @RequestParam String keyword) {
+        alarmService.updateNoticeAndMatchKeywordTest(SSAID, keyword);
+    }
+
     @Operation(summary = "키워드 별 미확인 알림 여부 확인", description = "사용자 SSAID와 키워드로 미확인 알림이 있는지 확인합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "성공적으로 확인됨"),

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/repository/AlarmRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/repository/AlarmRepository.java
@@ -11,6 +11,9 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
 
     boolean existsByUserIdAndIsViewedFalse(Long userId);
 
+    List<Alarm> findALLByUserIdAndKeywordOrderById (Long userId, String keyword);
+
     List<Alarm> findALLByUserIdAndKeyword (Long userId, String keyword);
 
+    List<Alarm> findALLByNoticeTypeAndNoticeID (String noticeType, Long noticeID);
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/repository/BookmarkRepository.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/repository/BookmarkRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
@@ -15,4 +16,5 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     boolean existsByCategoryAndNoticeIDAndUser(String category, Long noticeID, User user);
     List<Bookmark> findByUserAndCategoryOrderByCreatedAtDesc(User user, String category);
     List<Bookmark> findTop3ByUserAndCategoryOrderByCreatedAtDesc(User user, String category);
+    List<Bookmark> findALLByCategoryAndNoticeID (String category, Long noticeID);
 }

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/service/AlarmService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/service/AlarmService.java
@@ -110,39 +110,19 @@ public class AlarmService {
         }
     }
 
-    public void updateNoticeAndMatchKeywordTest(){
-        List<CrawlingNum> crawlingNums;
+    public void updateNoticeAndMatchKeywordTest(String SSAID, String keyword){
+        String keywordWithoutSpace = keyword.replace(" ", "");
 
-        try {
-            crawlingNums = crawlingNumRepository.findAll();
-        } catch (Exception e) {
-            throw new RuntimeException("크롤링 번호 레코드를 가져오는 동안 오류가 발생했습니다.", e);
-        }
+        List<AllNoticesView> allNoticesViews = allNoticeViewRepository.findByTitleContainingKeyword(keywordWithoutSpace);
 
-        for (CrawlingNum crawlingNum : crawlingNums) {
-            List<AllNoticesView> allNoticesViews;
+        User user = userRepository.findBySsaid(SSAID)
+                .orElseThrow(() -> new RuntimeException("User not found"));
 
-            try {
-                allNoticesViews = allNoticeViewRepository.findNewNoticesByCategory(crawlingNum.getNoticeType(), crawlingNum.getNoticeID());
+        for (AllNoticesView notice : allNoticesViews) {
+            Alarm alarm = new Alarm(notice.getId(), notice.getTableName(), user, notice.getTitle(), keyword);
 
-            } catch (Exception e) {
-                throw new RuntimeException(crawlingNum.getNoticeType() + "의 새로운 공지사항을 가져오는 중 오류가 발생했습니다.", e);
-            }
-
-            for (Keyword keyword : keywordRepository.findAll()) {
-                for (AllNoticesView notice : allNoticesViews) {
-                    String titleWithoutSpace = notice.getTitle().replace(" ", "");
-
-                    if (titleWithoutSpace.contains(keyword.getKeyword())) {
-                        try{
-                            Alarm alarm = new Alarm(notice.getId(), notice.getTableName(), keyword.getUser(), notice.getTitle(), keyword.getKeyword());
-
-                            fcmService.sendFCMMessage(alarm, keyword.getKeyword());
-                        } catch (Exception e) {
-                            throw new RuntimeException("유저 알림을 저장하거나, fcm 알림을 보내는 도중 오류가 발생했습니다.", e);
-                        }
-                    }
-                }
+            if (alarm.getUser().getAlarmEnabled()) {
+                fcmService.sendFCMMessage(alarm, keyword);
             }
         }
     }
@@ -202,7 +182,7 @@ public class AlarmService {
         if (userOpt.isPresent()) {
             User user = userOpt.get();
 
-            List<Alarm> alarms = alarmRepository.findALLByUserIdAndKeyword(user.getId(), keyword);
+            List<Alarm> alarms = alarmRepository.findALLByUserIdAndKeywordOrderById(user.getId(), keyword);
 
             List<AlarmDto> alarmDtos = new ArrayList<>();
 

--- a/src/main/java/depth/mvp/thinkerbell/domain/user/service/KeywordSaveService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/user/service/KeywordSaveService.java
@@ -2,7 +2,6 @@ package depth.mvp.thinkerbell.domain.user.service;
 
 import depth.mvp.thinkerbell.domain.notice.entity.AllNoticesView;
 import depth.mvp.thinkerbell.domain.notice.repository.AllNoticeViewRepository;
-import depth.mvp.thinkerbell.domain.user.entity.Alarm;
 import depth.mvp.thinkerbell.domain.user.entity.Keyword;
 import depth.mvp.thinkerbell.domain.user.entity.User;
 import depth.mvp.thinkerbell.domain.user.repository.AlarmRepository;
@@ -34,16 +33,10 @@ public class KeywordSaveService {
 
         Optional<User> user = userRepository.findBySsaid(userID);
 
-        List<AllNoticesView> views = allNoticeViewRepository.findByTitleContainingKeyword(keywordWithoutSpaces);
 
         if (user.isPresent()) {
             User userEntity = user.get();
             keywordRepository.save(new Keyword(keywordWithoutSpaces, userEntity));
-
-            for (AllNoticesView allNoticesView : views) {
-                Alarm alarm = new Alarm(allNoticesView.getId(), allNoticesView.getTableName(), userEntity, allNoticesView.getTitle(), keyword);
-                alarmRepository.save(alarm);
-            }
 
             return true;
         } else {

--- a/src/main/resources/Categories.json
+++ b/src/main/resources/Categories.json
@@ -1,6 +1,6 @@
 {
   "academic_notice": "학사 공지",
-  "bidding_notice": "입철 공지",
+  "bidding_notice": "입찰 공지",
   "career_notice": "진로/취업/창업 공지",
   "dormitory_entry_notice": "기숙사 입/퇴사 공지",
   "dormitory_notice": "기숙사 공지",
@@ -9,6 +9,7 @@
   "library_notice": "도서관 공지",
   "normal_notice": "일반 공지",
   "revision_notice": "학칙개정 사전공고",
+  "safety_notice": "대학 안전 공지",
   "scholarship_notice": "장학/학자금 공지",
   "student_acts_notice": "학생활동 공지",
   "teaching_notice": "교직 공지"

--- a/src/main/resources/Category.json
+++ b/src/main/resources/Category.json
@@ -9,6 +9,7 @@
   "library_notice": "LibraryNotice",
   "normal_notice": "NormalNotice",
   "revision_notice": "RevisionNotice",
+  "safety_notice": "SafetyNotice",
   "scholarship_notice": "ScholarshipNotice",
   "student_acts_notice": "StudentActsNotice",
   "teaching_notice": "TeachingNotice"


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] 키워드와 관련된 모든 공지사항이 보이는 기능 제거 
- [x] json 파일에 누락된 부서 추가
- [x] 알림 테스트 기능 추가
- [x] 공지사항 삭제 시에 필요한 메서드 추가

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
공지사항 삭제와 관련해서 기간이 아직 결정되지 않아서 JPA 메서드 커밋했습니다.
삭제 메서드는 만들어져 있는데 회의 이후에 삭제 기간만 정해지면 수정해서 커밋하겠습니다.

알림 테스트 기능을 추가했습니다. SSAID와 키워드를 입력하면 저장된 모든 공지에서 키워드와 관련한 공지가 알림이 가능 방식입니다.
원래 알림 기능에는 최신 공지사항 id를 유지해서 당일에 업로드 된 공지 중에서만 알림이 발송 되고 있습니다.
테스트에서는 알림이 보내지는 것을 확인해야해서 위와 같은 방식으로 메서드가 설계되지 않았습니다.
따라서 공지사항의 개수가 적은 키워드를 설정해서 테스트 용으로 진행해야 할 것 같습니다.

## Reference 🔬
 <!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
