### PR TITLE
[HOTFIX] fcm 알림 전송 로직 try-catch 추가

### DIFF
--- a/src/main/java/depth/mvp/thinkerbell/domain/notice/service/NoticeDeleteService.java
+++ b/src/main/java/depth/mvp/thinkerbell/domain/notice/service/NoticeDeleteService.java
@@ -332,7 +332,7 @@ public class NoticeDeleteService {
             LocalDate noticeDate = notice.getPubDate();
             Period period = Period.between(noticeDate, currentDate);
 
-            if (period.getMonths() == 9 && period.getDays() == 20){
+            if (period.getYears() >= 3){
                 List<Bookmark> bookmarks = bookmarkRepository.findALLByCategoryAndNoticeID("TeachingNotice", notice.getId());
                 bookmarkRepository.deleteAll(bookmarks);
 


### PR DESCRIPTION
## 작업 내용 👨🏻‍💻
<!-- 작업한 내용을 적고 완료했다면 []안에 x를 넣어주세요! -->
- [x] fcm 알림 전송 로직 try-catch 추가
- [x] 교직 공지 3년 이상 공지사항 지우기

## To Reviewers 💬
<!-- 리뷰어(팀원)들이 중점적으로 봐야할 부분, 알고있어야 할 사항들을 적어주세요! -->
이전에 올린 공지사항 삭제 클래스에서 교직 공지가 이전 기준으로 삭제되고 있어서 변경하였습니다.

fcm 알림을 보내는 중 fcm token이 유효하지 않으면 RuntimeException이 되게 했었습니다.
이후에 스케줄링 함수가 진행되는 동안 알림에서 RuntimeException이 되면 알림이 보내지지 않는 현상을 발견했고
현재는 예외처리를 통해서 알림이 전송되지 않는 경우에는 로그를 남기고 스케줄링 작업이 멈추지 않게 바꾸었습니다.

## Reference 🔬
 <!-- 개발 중 참고한 레퍼런스, 팀원들도 읽어두면 좋은 글이 있다면 링크를 달아주세요! -->
https://velog.io/@redgem92/Java-예외-처리